### PR TITLE
Add stochastic test marker

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ def pytest_configure(config):
                    " and providing access to statistical analysis of the runs via the injected `stochastic_run` "
                    "fixture. Optionally specify `max_samples`. By default it is equal to `sample_size`. If it is "
                    "bigger, then additional samples are drawn if the test fails after taking `sample_size` samples, up"
-                   "to the specified `max_samples`. If it is smaller than `sample_size` it is capped to `sample_size`")
+                   "to the specified `max_samples`. If it is smaller than `max_samples` it is capped to `sample_size`")
 
 
 class StochasticRunRecorder:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,10 +4,12 @@ try:
 except ImportError:
     raise ImportError("reinforcement requires tensorflow 1.14")
 
+import contextlib
 import itertools
 
 import numpy as np
 import pytest
+from _pytest.runner import runtestprotocol
 
 from reinforcement.trajectories import history_to_trajectory
 
@@ -19,6 +21,82 @@ def pytest_addoption(parser):
     parser.addoption(
         "--plot-policy", action="store_true", default=False, help="plots policy parameter information for certain tests"
     )
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "stochastic(sample_size): mark a test as stochastic running it `sample_size` times and providing "
+                   "access to statistical analysis of the runs via the injected `stochastic_run` fixture.")
+
+
+class StochasticRunRecorder:
+    def __init__(self):
+        self._results = list()
+
+    @contextlib.contextmanager
+    def current_run(self):
+        self._results.clear()
+        yield
+
+    def record(self, result):
+        self._results.append(result)
+
+    def count(self, result_equals):
+        return self._results.count(result_equals)
+
+    def __len__(self):
+        return len(self._results)
+
+
+_RECORDER = StochasticRunRecorder()
+
+
+def pytest_runtest_protocol(item, nextitem):
+    m = _get_marker(item)
+    if m is None:
+        return None
+
+    reports = None
+    with _RECORDER.current_run():
+        max_n, n = _get_sample_range(m)
+        s = 0
+        while s < n:
+            item.ihook.pytest_runtest_logstart(nodeid=item.nodeid, location=item.location)
+            reports = runtestprotocol(item, nextitem=nextitem, log=False)
+            s += 1
+            if s == n and _has_failed(reports):
+                n = min(n + 1, max_n)
+
+    _report_last_run(item, reports)
+    return True
+
+
+def _get_marker(item):
+    try:
+        return item.get_closest_marker("stochastic")
+    except AttributeError:
+        return item.get_marker("stochastic")
+
+
+def _get_sample_range(m):
+    n = m.kwargs.get('sample_size', m.args[0])
+    max_n = max(m.kwargs.get('max_samples', n), n)
+    return max_n, n
+
+
+def _has_failed(reports):
+    return any(r.failed for r in reports if r.when == 'call')
+
+
+def _report_last_run(item, reports):
+    for r in reports:
+        item.ihook.pytest_runtest_logreport(report=r)
+    item.ihook.pytest_runtest_logfinish(nodeid=item.nodeid, location=item.location)
+
+
+@pytest.fixture
+def stochastic_run(request):
+    return _RECORDER
 
 
 class TrajectoryBuilder:


### PR DESCRIPTION
To make the reinforce and RL tests more reliable, a stochastic test
marker has been added, which provides a mechanism to record multiple
test runs and assert them on stochastic analysis. In this case baseline
improvement is now measured over multiple runs and can be asserted
statistically (i.e. that in most cases using a baseline is beneficial
to learning, respectively not using it hinders it in most cases.