### PR TITLE
Pin converage to 4.5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
 install:
   - make install TARGET=test
 script:
+  - pip install coverage==4.5.4
   - pip install python-coveralls
   - scripts/embedmd -d README.md
   - make coverage


### PR DESCRIPTION
The new coverage version has some breaking changes and is not backwards
compatible. See https://github.com/z4r/python-coveralls/issues/73